### PR TITLE
Clean comments in langgraph agents

### DIFF
--- a/langgraph/entity_extraction_agent_js/graph.ts
+++ b/langgraph/entity_extraction_agent_js/graph.ts
@@ -36,10 +36,9 @@ async function callModel(
   if (state.messages.length > 0) {
     const lastMessageFromState = state.messages[state.messages.length - 1];
 
-    // Check if it's a ToolMessage and specifically from extract_entities
-    // The .type property is a more idiomatic way to check message types in LangChain
+    // Check if it's a ToolMessage from extract_entities
     if (lastMessageFromState && lastMessageFromState.constructor.name === "ToolMessage") {
-      const toolMessage = lastMessageFromState as ToolMessage; // Cast after check
+      const toolMessage = lastMessageFromState as ToolMessage;
       if (toolMessage.name === "extract_entities") {
         if (typeof toolMessage.content === 'string') {
           try {

--- a/langgraph/entity_extraction_agent_js/tools.ts
+++ b/langgraph/entity_extraction_agent_js/tools.ts
@@ -5,13 +5,6 @@
 import { DynamicStructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
 
-// Environment variable checks (optional, but good practice)
-// It's better to handle these within the tool functions or ensure they are set in the environment
-// For simplicity in this example, we'll assume they are set.
-// const JINA_API_KEY = process.env.JINA_API_KEY;
-// const SEARCH1API_KEY = process.env.SEARCH1API_KEY;
-// const SUPADATA_API_KEY = process.env.SUPADATA_API_KEY;
-
 /**
  * Helper function to remove markdown images from text.
  */
@@ -166,4 +159,4 @@ export const TOOLS = [
   scrapeWebpages,
   batchWebSearch,
   extractEntities,
-];
+]; // order matters for tool calling

--- a/langgraph/entity_extraction_agent_js/utils.ts
+++ b/langgraph/entity_extraction_agent_js/utils.ts
@@ -9,7 +9,7 @@ import { ChatGoogle } from "@langchain/google-webauth";
 export async function loadChatModel(fullySpecifiedName: string) {
   if (fullySpecifiedName.startsWith("gemini")) {
     return new ChatGoogle({
-      model: fullySpecifiedName, // The API reference uses modelName, the doc uses model
+      model: fullySpecifiedName,
       apiVersion: "v1beta",
       platformType: "gai",
       maxReasoningTokens: 0

--- a/langgraph/entity_qualification_agent_js/graph.ts
+++ b/langgraph/entity_qualification_agent_js/graph.ts
@@ -17,8 +17,7 @@ export interface QualificationItem {
   entity_name: string;
   qualified: boolean;
   reasoning: string;
-  // Allow other properties as Python version uses Dict[str, Any]
-  [key: string]: any;
+  [key: string]: any; // allow extra fields
 }
 
 // Define the new state structure including entities
@@ -27,7 +26,6 @@ const AppStateAnnotation = Annotation.Root({
     reducer: (currentMessages, newMessages) => currentMessages.concat(newMessages),
     default: () => [],
   }),
-  // This corresponds to 'entities_to_qualify' from the Python agent
   entitiesToQualify: Annotation<string[]>({
     reducer: (currentState, updateValue) => {
       // The existing 'entities' reducer was a concat.

--- a/langgraph/entity_qualification_agent_js/utils.ts
+++ b/langgraph/entity_qualification_agent_js/utils.ts
@@ -9,7 +9,7 @@ import { ChatGoogle } from "@langchain/google-webauth";
 export async function loadChatModel(fullySpecifiedName: string) {
   if (fullySpecifiedName.startsWith("gemini")) {
     return new ChatGoogle({
-      model: fullySpecifiedName, // The API reference uses modelName, the doc uses model
+      model: fullySpecifiedName,
       apiVersion: "v1beta",
       platformType: "gai",
       maxReasoningTokens: 0

--- a/langgraph/list_generation_agent_js/tools.ts
+++ b/langgraph/list_generation_agent_js/tools.ts
@@ -5,13 +5,6 @@
 import { DynamicStructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
 
-// Environment variable checks (optional, but good practice)
-// It's better to handle these within the tool functions or ensure they are set in the environment
-// For simplicity in this example, we'll assume they are set.
-// const JINA_API_KEY = process.env.JINA_API_KEY;
-// const SEARCH1API_KEY = process.env.SEARCH1API_KEY;
-// const SUPADATA_API_KEY = process.env.SUPADATA_API_KEY;
-
 /**
  * Helper function to remove markdown images from text.
  */
@@ -144,4 +137,4 @@ const batchWebSearch = new DynamicStructuredTool({
 export const TOOLS = [
   scrapeWebpages,
   batchWebSearch,
-];
+]; // tools available during list generation

--- a/langgraph/list_generation_agent_js/utils.ts
+++ b/langgraph/list_generation_agent_js/utils.ts
@@ -9,7 +9,7 @@ import { ChatGoogle } from "@langchain/google-webauth";
 export async function loadChatModel(fullySpecifiedName: string) {
   if (fullySpecifiedName.startsWith("gemini")) {
     return new ChatGoogle({
-      model: fullySpecifiedName, // The API reference uses modelName, the doc uses model
+      model: fullySpecifiedName,
       apiVersion: "v1beta",
       platformType: "gai",
       maxReasoningTokens: 0


### PR DESCRIPTION
## Summary
- prune outdated comments in TypeScript agents
- clarify tool exports and misc notes
- keep helpful comments for readability

## Testing
- `yarn test` *(fails: unable to download yarn)*
- `npm test` *(fails: module not found)*