### PR TITLE
Replace scrapeWebpages with Exa webCrawl tool

### DIFF
--- a/langgraph/entity_extraction_agent_js/package.json
+++ b/langgraph/entity_extraction_agent_js/package.json
@@ -25,6 +25,7 @@
     "@langchain/google-webauth": "^0.2.9",
     "@langchain/langgraph": "^0.2.67",
     "@langchain/langgraph-cli": "^0.0.34",
+    "exa-js": "^1.7.2",
     "langchain": "^0.3.14",
     "zod": "^3.24.4"
   },

--- a/langgraph/entity_qualification_agent_js/package.json
+++ b/langgraph/entity_qualification_agent_js/package.json
@@ -25,6 +25,7 @@
     "@langchain/google-webauth": "^0.2.9",
     "@langchain/langgraph": "^0.2.67",
     "@langchain/langgraph-cli": "^0.0.34",
+    "exa-js": "^1.7.2",
     "langchain": "^0.3.14"
   },
   "devDependencies": {

--- a/langgraph/entity_qualification_agent_js/prompts.ts
+++ b/langgraph/entity_qualification_agent_js/prompts.ts
@@ -13,7 +13,7 @@ Your primary objective is to analyze a list of entities provided in the state ('
 
 ### Your Process:
 1.  **Review Entities**: Examine the 'entitiesToQualify' list from the current state.
-2.  **Gather Information**: Use available tools (e.g., 'scrape_webpages', 'batch_web_search') to find information about each entity relevant to the qualification criteria.
+2.  **Gather Information**: Use available tools (e.g., 'web_crawl', 'batch_web_search') to find information about each entity relevant to the qualification criteria.
     *   Prioritize batch operations for efficiency.
     *   If an entity is clearly not qualified based on initial findings, you can deprioritize further deep research for it to save time, but ensure you eventually record a qualification status for it.
 3.  **Qualify Entities**: For each entity, determine if it's qualified (true/false) and provide clear reasoning.

--- a/langgraph/entity_qualification_agent_js/tools.ts
+++ b/langgraph/entity_qualification_agent_js/tools.ts
@@ -5,74 +5,65 @@
 import { DynamicStructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
 import { QualificationItem } from "./graph.js";
+import { Exa } from 'exa-js';
 
-
-/**
- * Helper function to remove markdown images from text.
- */
-function removeMarkdownImages(content: string): string {
-  const pattern = /!\[([^\]]*)\]\(([^\)]+)\)/g;
-  return content.replace(pattern, "");
+// Define an interface for the search result object from Exa
+interface ExaSearchResult {
+  id: string;
+  url?: string;
+  title?: string | null;
+  text?: string;
+  // Add other fields if necessary based on what you expect to use
 }
 
-const scrapeWebpagesSchema = z.object({
+interface ExaContentsResponse {
+  results: ExaSearchResult[];
+}
+
+const webCrawlSchema = z.object({
   links: z.array(z.string()).describe("A list of strings (URLs) to scrape."),
 });
 /**
- * Scrapes web pages using Jina AI.
+ * Scrapes web pages using Exa AI.
  */
-const scrapeWebpages = new DynamicStructuredTool({
-  name: "scrape_webpages",
+const webCrawl = new DynamicStructuredTool({
+  name: "web_crawl",
   description:
-    "Scrape the provided web pages for detailed information. Use with less than 20 links (most optimally less than 10). Input format: {\"links\": [\"site1.com\", \"site2.com\", ...]}",
-  schema: scrapeWebpagesSchema, // Schema for validation by the framework
-  func: async (args: z.infer<typeof scrapeWebpagesSchema>) => {
+    "Scrape the provided web pages for detailed information using Exa AI. Use with less than 20 links (most optimally less than 10). Input format: {\"links\": [\"site1.com\", \"site2.com\", ...]}",
+  schema: webCrawlSchema, // Schema for validation by the framework
+  func: async (args: z.infer<typeof webCrawlSchema>) => {
     const { links } = args;
 
-    const JINA_API_KEY = process.env.JINA_API_KEY;
-    if (!JINA_API_KEY) {
-      return "Error: JINA_API_KEY not found in environment variables.";
+    const EXA_API_KEY = process.env.EXA_API_KEY;
+    if (!EXA_API_KEY) {
+      return "Error: EXA_API_KEY not found in environment variables.";
     }
     if (!links || links.length === 0) {
       return "Error: No URLs provided.";
     }
 
-    const headers = { Authorization: `Bearer ${JINA_API_KEY}` };
+    const exa = new Exa(EXA_API_KEY);
     let combinedContent: string[] = [];
 
-    const scrapeUrl = async (link: string): Promise<string> => {
-      try {
-        const fullUrl = `https://r.jina.ai/${link}`;
-        const response = await fetch(fullUrl, {
-          headers,
-          signal: AbortSignal.timeout(10000), // 10 second timeout
+    try {
+      const contentsResponse: ExaContentsResponse = await exa.getContents(links) as ExaContentsResponse;
+
+      if (contentsResponse.results && contentsResponse.results.length > 0) {
+        combinedContent = contentsResponse.results.map((result: ExaSearchResult) => {
+          let content = result.text || `No content retrieved for ${result.url || result.id}`;
+          content = content.replace(/\$/g, "\\$"); // Escape dollar signs
+          return content;
         });
-        if (!response.ok) {
-          return `Error scraping ${link}: ${response.status} ${response.statusText}`;
-        }
-        let content = await response.text();
-        content = content.replace(/\$/g, "\\$"); // Escape dollar signs
-        content = removeMarkdownImages(content);
-        return content;
-      } catch (error: any) {
-        if (error.name === 'TimeoutError') {
-          return `Timeout for ${link}: Request timed out after 10 seconds.`;
-        }
-        return `Error scraping ${link}: ${error.message}`;
+      } else {
+        return "Error: No content retrieved from Exa or empty results.";
       }
-    };
-
-    const tasks = links.map(scrapeUrl);
-    const results = await Promise.all(tasks);
-    combinedContent = results;
-
-    let finalContent = combinedContent.join("\n\n");
-    if (finalContent.length > 200000) {
-      finalContent =
-        finalContent.substring(0, 200000) +
-        "\n\n[Content truncated due to length...]";
+    } catch (error: any) {
+      // Handle potential errors from the Exa API call
+      return `Error scraping with Exa: ${error.message}`;
     }
-    return finalContent;
+
+    // Return the array of content strings directly
+    return combinedContent;
   },
 });
 
@@ -307,7 +298,7 @@ export const updateQualificationSummaryStateTool = new DynamicStructuredTool({
 });
 
 export const AGENT_TOOLS = [
-  scrapeWebpages,
+  webCrawl,
   batchWebSearch,
   extractEntities,
   qualifyAllEntitiesTool,


### PR DESCRIPTION
## Summary
- clean up Exa-based webCrawl tool
- remove unused markdown helpers
- rename schema variable and update prompt reference

## Testing
- `npm test` (entity_extraction_agent_js) – fails: Cannot find module 'jest'
- `npm test` (entity_qualification_agent_js) – fails: Cannot find module 'jest'
- `npm test` (exa_query_agent) – fails: Cannot find module 'jest'
