### PR TITLE
Adjust tab and input width

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,7 +4,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 export default function Home() {
   return (
     <div className="flex items-center justify-center min-h-screen px-4">
-      <div className="text-center max-w-md w-full">
+      <div className="text-center max-w-2xl w-full">
         <h1 className="text-2xl font-bold tracking-tight">Find your (almost) perfect list</h1>
         
         <Tabs defaultValue="people" className="w-full mt-8">


### PR DESCRIPTION
## Summary
- expand page layout container so tabs and input are wider

## Testing
- `npm run lint` *(fails: `next` not found)*