### PR TITLE
Adjust homepage layout spacing

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,11 +3,11 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 export default function Home() {
   return (
-    <div className="flex items-center justify-center min-h-screen px-4">
+    <div className="flex items-center justify-center min-h-screen px-4 -mt-20">
       <div className="text-center max-w-lg w-full">
         <h1 className="text-2xl font-bold tracking-tight">Find your (almost) perfect list</h1>
-        
-        <Tabs defaultValue="people" className="w-full mt-8">
+
+        <Tabs defaultValue="people" className="w-full mt-4">
           <TabsList className="grid grid-cols-4 w-full">
             <TabsTrigger value="people">People</TabsTrigger>
             <TabsTrigger value="companies">Companies</TabsTrigger>


### PR DESCRIPTION
## Summary
- tweak layout to pull input box into screen center
- reduce gap between title and tabs

## Testing
- `npm run lint` *(fails: next not found)*