### PR TITLE
Add icons to tabs and enlarge input font

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Users, Building2, BookOpen, Newspaper } from "lucide-react";
 
 export default function Home() {
   return (
@@ -9,10 +10,22 @@ export default function Home() {
 
         <Tabs defaultValue="people" className="w-full mt-4">
           <TabsList className="grid grid-cols-4 w-full">
-            <TabsTrigger value="people">People</TabsTrigger>
-            <TabsTrigger value="companies">Companies</TabsTrigger>
-            <TabsTrigger value="research">Papers</TabsTrigger>
-            <TabsTrigger value="articles">Articles</TabsTrigger>
+            <TabsTrigger value="people">
+              <Users />
+              People
+            </TabsTrigger>
+            <TabsTrigger value="companies">
+              <Building2 />
+              Companies
+            </TabsTrigger>
+            <TabsTrigger value="research">
+              <BookOpen />
+              Papers
+            </TabsTrigger>
+            <TabsTrigger value="articles">
+              <Newspaper />
+              Articles
+            </TabsTrigger>
           </TabsList>
         </Tabs>
         

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -49,7 +49,7 @@ function Input({
         onChange={handleChange} // Use the new handleChange
         data-slot="input"
         className={cn(
-          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pr-10 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pr-10 text-lg shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-base",
           "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
           "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
           className


### PR DESCRIPTION
## Summary
- improve Input component's default font size
- add lucide-react icons to the tabs on the home page

## Testing
- `npm run lint` *(fails: next not found)*