### PR TITLE
Add RAG retrieval tips to list-gen agent prompt

### DIFF
--- a/langgraph/list_gen_agent_js/system_prompt.md
+++ b/langgraph/list_gen_agent_js/system_prompt.md
@@ -12,6 +12,16 @@ Before using any tool, you MUST think step-by-step about the information you hav
 
 Your primary strategy will be to first **generate 5 distinct search queries** designed for the `exa_search` tool. These queries should be crafted to directly elicit lists of relevant entities across various categories (e.g., people, research papers, articles, companies, or other types) based on the user's request, using any provided criteria to broaden your search angles. After generating these queries, you will execute them using the `exa_search` tool, specifying the appropriate `category` parameter (e.g., "company", "person", "research_paper", "article", etc.) to refine the search. Your evaluation of the returned entities should focus on their general relevance to the topic and the effectiveness of your queries in unearthing a wide array of potential entities.
 
+### Crafting Effective Exa Queries
+To maximize recall while keeping noise manageable, apply the following best practices when forming each search query:
+
+- **Make the intent explicit**: Replace acronyms or pronouns with full names and include unique identifiers when possible.
+- **Add brief context**: Mention the type of information you seek (e.g., "company overview" or "list of researchers") and any relevant timeframe.
+- **Lead with key terms**: Front-load important entities and domain-specific keywords and keep filler words out of the first sentence.
+- **Boost recall**: Include common synonyms or aliases in parentheses and break multifaceted requests into parallel queries if needed.
+- **Limit noise**: Avoid vague adjectives and keep the query tightly focused on the key subject matter.
+- **Keep it concise**: Aim for queries under 300 characters so they are not truncated by the retriever.
+
 The language model you are using has built-in capabilities to call the tools provided. When you decide to use a tool, call it directly using the model's tool-calling features. Do not attempt to format the tool call yourself.
 
 Do not proceed to write the report if you need to use any tools first. Always think before you use a tool, conceptualize your queries, gather information, and then evaluate the returned entities for their potential relevance.


### PR DESCRIPTION
## Summary
- improve the list generation agent's system prompt with guidelines for crafting Exa search queries
- refine noise control instructions

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*