### PR TITLE
Implement indexed entity state

### DIFF
--- a/langgraph/entity_qualification_agent_js/system_prompt.md
+++ b/langgraph/entity_qualification_agent_js/system_prompt.md
@@ -1,6 +1,6 @@
 ## Role and Mission: Entity Qualification Agent
 
-Your primary objective is to efficiently analyze and qualify (or disqualify) a list of entities provided in the state ('entitiesToQualify'). These entities can be companies, people, research papers, articles, or other types. Your qualification must be based on the criteria provided in the state ('qualificationCriteria').
+Your primary objective is to efficiently analyze and qualify (or disqualify) a list of entities provided in the state ('entitiesToQualify'). These entities can be companies, people, research papers, articles, or other types. Each entity item includes an `index` (unique identifier), a `name`, and a `url`. Your qualification must be based on the criteria provided in the state ('qualificationCriteria').
 
 ### Core Operational Principles:
 
@@ -20,14 +20,14 @@ Your primary objective is to efficiently analyze and qualify (or disqualify) a l
 
 1.  **Comprehensive Update**: When you have processed the entities (i.e., gathered sufficient information, reached search limits, or decided on disqualification for each), use the `qualify_entities` tool.
     - **IMPORTANT**: This tool call MUST provide the complete, updated list of qualification summaries for ALL entities you have evaluated or re-evaluated in the current operational step. This tool REPLACES the entire `qualificationSummary` in the state.
-    - Each summary item must include `entity_name`, `qualified` (boolean), and `reasoning` (string).
+    - Each summary item must include `index` (the integer identifier from `entitiesToQualify`), `entity_name`, `qualified` (boolean), and `reasoning` (string).
     - Example tool call (ensure it reflects all processed entities):
       {
       "name": "qualify_entities",
       "args": {
       "summary": [
-      { "entity_name": "Dr. Jane Smith", "qualified": true, "reasoning": "Authored over 20 peer-reviewed articles on AI research, meeting the >15 publications criterion." },
-      { "entity_name": "New Startup Inc.", "qualified": false, "reasoning": "Revenue reported as $500k, below the $1M criterion. No further searches conducted after this was found." },
+      { "index": 0, "entity_name": "Dr. Jane Smith", "qualified": true, "reasoning": "Authored over 20 peer-reviewed articles on AI research, meeting the >15 publications criterion." },
+      { "index": 1, "entity_name": "New Startup Inc.", "qualified": false, "reasoning": "Revenue reported as $500k, below the $1M criterion. No further searches conducted after this was found." },
       // ... include all other entities processed in this step
       ]
       }

--- a/langgraph/entity_qualification_agent_js/tools.ts
+++ b/langgraph/entity_qualification_agent_js/tools.ts
@@ -146,6 +146,7 @@ const qualifyAllEntitiesSchema = z.object({
     .array(
       z
         .object({
+          index: z.number(),
           entity_name: z.string(),
           qualified: z.boolean(),
           reasoning: z.string(),
@@ -179,14 +180,21 @@ export const qualifyAllEntitiesTool = new DynamicStructuredTool({
 // Schema for verifyQualificationConsistencyTool
 const verifyInputsSchema = z.object({
   entitiesToQualify: z
-    .array(z.string())
+    .array(
+      z.object({
+        index: z.number(),
+        name: z.string(),
+        url: z.string(),
+      })
+    )
     .describe(
-      "The list of entity names that should be qualified (from state).",
+      "The list of entities that should be qualified (from state).",
     ),
   qualificationSummary: z
     .array(
       z
         .object({
+          index: z.number(),
           entity_name: z.string(),
           qualified: z.boolean(),
           reasoning: z.string(),
@@ -210,6 +218,7 @@ export const verifyQualificationConsistencyTool = new DynamicStructuredTool({
     const summaryEntityNames = qualificationSummary.map(
       (item: QualificationItem) => item.entity_name,
     );
+    const qualifyNames = entitiesToQualify.map((e) => e.name);
 
     const issues: Record<string, any> = {
       duplicates_found_now: [],
@@ -232,10 +241,10 @@ export const verifyQualificationConsistencyTool = new DynamicStructuredTool({
       .map(([name]) => name);
 
     const summarySet = new Set(summaryEntityNames);
-    const entitiesToQualifySet = new Set(entitiesToQualify);
+    const entitiesToQualifySet = new Set(qualifyNames);
 
     // Calculate initial missing and extra entities
-    const initialMissingEntities = entitiesToQualify.filter(
+    const initialMissingEntities = qualifyNames.filter(
       (name: string) => !summarySet.has(name),
     );
     issues.missing_entities_now = [...initialMissingEntities]; // Store the full list
@@ -287,6 +296,7 @@ const overwriteSummarySchema = z.object({
     .array(
       z
         .object({
+          index: z.number(),
           entity_name: z.string(),
           qualified: z.boolean(),
           reasoning: z.string(),

--- a/langgraph/entity_qualification_agent_js/verification_prompt_template.md
+++ b/langgraph/entity_qualification_agent_js/verification_prompt_template.md
@@ -11,7 +11,7 @@ You are an Entity Data Verification Specialist. Your task is to ensure that the 
 ### Your Action:
 
 Carefully review the 'Verification Issues', especially the `potential_name_mismatches_details` field.
-Your goal is to produce a new, complete 'qualificationSummary' that perfectly aligns with the 'Entities to Qualify' list.
+Your goal is to produce a new, complete 'qualificationSummary' that perfectly aligns with the 'Entities to Qualify' list. Each summary item must include the `index` provided with the entity.
 
 1.  **Correct Names**: For each entity, ensure its `entity_name` in the new summary **exactly matches** the corresponding name in the 'Entities to Qualify' list.
     - If `potential_name_mismatches_details` (within 'Verification Issues') lists an item (e.g., `summary_name`: "entityX", `qualify_list_name`: "entityX "), you **MUST** use the `qualify_list_name` (e.g., "entityX ") as the correct `entity_name` in your new summary for that entity.
@@ -28,6 +28,7 @@ Example tool call:
 "args": {
 "summary": [
 {
+"index": 0,
 "entity_name": "ExactNameFromEntitiesToQualify",
 "qualified": true,
 "reasoning": "..."

--- a/langgraph/graph.ts
+++ b/langgraph/graph.ts
@@ -56,7 +56,7 @@ const ParentAppStateAnnotation = Annotation.Root({
     },
     default: () => [],
   }),
-  entitiesToQualify: Annotation<string[]>({
+  entitiesToQualify: Annotation<Entity[]>({
     reducer: (_currentState, updateValue) => updateValue,
     default: () => [],
   }),
@@ -308,9 +308,12 @@ async function entityProcessingNode(
     processedEntityCount,
     nextBatchEndIndex,
   );
-  const batchEntityNamesToQualify = batchToQualifyObjects.map(
-    (entity: Entity) => entity.name,
-  );
+  const batchEntitiesToQualify = batchToQualifyObjects.map((entity: Entity) => ({
+    index: entity.index,
+    name: entity.name,
+    url: entity.url,
+  }));
+  const batchEntityNamesToQualify = batchEntitiesToQualify.map((e) => e.name);
 
   newParentMessages.push(
     new AIMessage(
@@ -319,7 +322,7 @@ async function entityProcessingNode(
   );
 
   const update: Partial<ParentAppStateUpdate> = {
-    entitiesToQualify: batchEntityNamesToQualify,
+    entitiesToQualify: batchEntitiesToQualify,
     processedEntityCount: nextBatchEndIndex,
     parentMessages: newParentMessages,
   };

--- a/langgraph/list_gen_agent_js/graph.ts
+++ b/langgraph/list_gen_agent_js/graph.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "url";
 
 // Define the structure for an entity
 export interface Entity {
+  index: number;
   name: string;
   url: string;
 }
@@ -188,8 +189,15 @@ async function callModel(
 
   const update: AppStateUpdate = { listGenMessages: [response] };
   if (parsedEntitiesFromTool && parsedEntitiesFromTool.length > 0) {
+    // Assign sequential indexes to each new entity before updating state
+    const baseIndex = state.entities.length;
+    const indexedEntities = parsedEntitiesFromTool.map((e, i) => ({
+      index: baseIndex + i,
+      name: e.name,
+      url: e.url,
+    }));
     // The reducer for 'entities' expects the new array of items to add/concat.
-    update.entities = parsedEntitiesFromTool;
+    update.entities = indexedEntities;
   }
   return update;
 }


### PR DESCRIPTION
## Summary
- include an `index` field in entity objects
- propagate indexed entities throughout parent graph
- update qualification agent state and tools to work with indices
- document index usage in prompts

## Testing
- `yarn test` *(fails: ConnectTimeoutError)*
- `npm test` *(fails: Cannot find module 'jest')*