### PR TITLE
Fix processedEntityCount propagation

### DIFF
--- a/langgraph/entity_qualification_agent_js/graph.ts
+++ b/langgraph/entity_qualification_agent_js/graph.ts
@@ -97,6 +97,11 @@ const AppStateAnnotation = Annotation.Root({
     reducer: (currentState, updateValue) => currentState.concat(updateValue), // Concat strategy
     default: () => [],
   }),
+  processedEntityCount: Annotation<number>({
+    reducer: (currentState, updateValue) =>
+      typeof updateValue === "number" ? updateValue : currentState,
+    default: () => 0,
+  }),
 });
 
 type AppState = typeof AppStateAnnotation.State;


### PR DESCRIPTION
## Summary
- add `processedEntityCount` to the qualification agent state so the parent workflow correctly tracks progress through entity batches

## Testing
- `npm test` (no tests found)
- `npm run lint` *(fails: No files matching the pattern "src" were found)*