### PR TITLE
Add persistent agent run provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,11 @@
 │   ├── app/
 │   │   ├── favicon.ico
 │   │   ├── globals.css
+│   │   ├── client-providers.tsx
 │   │   ├── layout.tsx
-│   │   └── page.tsx
+│   │   ├── page.tsx
+│   │   └── providers/
+│   │       └── agent-run-provider.tsx
 │   ├── components/
 │   ├── components.json
 │   ├── eslint.config.mjs

--- a/frontend/app/[uuid]/page.tsx
+++ b/frontend/app/[uuid]/page.tsx
@@ -8,7 +8,7 @@ export default async function UuidPage({
   const { uuid } = await params;
 
   return (
-    <ClientPageLayout uuid={uuid}>
+    <ClientPageLayout>
       <div className="shadow-lg rounded-lg p-6 sm:p-10 max-w-md w-full bg-card text-card-foreground">
         <h1 className="text-3xl sm:text-4xl font-bold mb-6">Item Details</h1>
         <div className="space-y-4 text-left">

--- a/frontend/app/client-providers.tsx
+++ b/frontend/app/client-providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
+import { AgentRunProvider } from "./providers/agent-run-provider";
 import React from "react";
 
 // Single QueryClient instance for all client-side React Query usage
@@ -12,17 +13,19 @@ const queryClient = new QueryClient();
 export function ClientProviders({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider
-        attribute="class"
-        defaultTheme="system"
-        enableSystem
-        disableTransitionOnChange
-      >
-        <TooltipProvider delayDuration={0}>
-          {children}
-          <Toaster />
-        </TooltipProvider>
-      </ThemeProvider>
+      <AgentRunProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <TooltipProvider delayDuration={0}>
+            {children}
+            <Toaster />
+          </TooltipProvider>
+        </ThemeProvider>
+      </AgentRunProvider>
     </QueryClientProvider>
   );
 } 

--- a/frontend/app/providers/agent-run-provider.tsx
+++ b/frontend/app/providers/agent-run-provider.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import type { Message as LangGraphMessage } from "@langchain/langgraph-sdk";
+import { useLangGraphStreamAndSend, processStreamError } from "@/hooks/use-agent-run";
+
+interface AgentRunCtx {
+  threadId: string | null;
+  messages: LangGraphMessage[];
+  isLoading: boolean;
+  error: Error | null;
+  send: (content: string) => void;
+  stop: () => void;
+  setThreadId: (id: string | null) => void;
+}
+
+const AgentRunContext = createContext<AgentRunCtx | undefined>(undefined);
+
+export function AgentRunProvider({ children }: { children: React.ReactNode }) {
+  const params = useParams() as { uuid?: string };
+  const slug = params?.uuid;
+  const [threadId, setThreadId] = useState<string | null>(slug ?? null);
+
+  useEffect(() => {
+    if (slug !== undefined) {
+      setThreadId(slug ?? null);
+    } else {
+      setThreadId(null);
+    }
+  }, [slug]);
+
+  const { messages, isLoading, error, send, stop } = useLangGraphStreamAndSend({
+    threadId,
+    onThreadId: setThreadId,
+  });
+
+  const value: AgentRunCtx = {
+    threadId,
+    messages,
+    isLoading,
+    error: processStreamError(error),
+    send,
+    stop,
+    setThreadId,
+  };
+
+  return <AgentRunContext.Provider value={value}>{children}</AgentRunContext.Provider>;
+}
+
+export function useAgentRunCtx() {
+  const ctx = useContext(AgentRunContext);
+  if (!ctx) {
+    throw new Error("useAgentRunCtx must be inside AgentRunProvider");
+  }
+  return ctx;
+}
+

--- a/frontend/components/ChatSidebar.tsx
+++ b/frontend/components/ChatSidebar.tsx
@@ -3,42 +3,22 @@ import { MessageInput } from "@/components/ui/message-input";
 import { MessageList } from "@/components/ui/message-list";
 import { SidebarToggle } from "@/components/ui/sidebar-toggle";
 import { useState } from "react"; // Keep for input state
-import { useAgentRun } from "@/hooks/use-agent-run";
-
-// Define the Message interface, matching the one from shadcn-chatbot-kit
-interface Message {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  createdAt?: Date;
-  attachments?: File[];
-}
+import { useAgentRunCtx } from "@/app/providers/agent-run-provider";
 
 interface ChatSidebarProps {
-  uuid: string;
   isOpen: boolean;
   toggleSidebar: () => void;
-  onNewThreadIdGenerated?: (threadId: string) => void;
 }
 
 export function ChatSidebar({
-  uuid,
   isOpen,
   toggleSidebar,
-  onNewThreadIdGenerated,
 }: ChatSidebarProps) {
-  // Use LangGraph agent hook for streaming messages and send functionality
   const {
     messages: agentMessages,
     isLoading: isGenerating,
     send: sendToAgent,
-    error: agentError,
-    stop: stopAgent,
-  } = useAgentRun({
-    threadId: uuid,
-    initialInput: undefined,
-    onThreadId: onNewThreadIdGenerated,
-  });
+  } = useAgentRunCtx();
   const [input, setInput] = useState("");
 
   const handleInputChange = (

--- a/frontend/components/ClientPageLayout.tsx
+++ b/frontend/components/ClientPageLayout.tsx
@@ -1,35 +1,18 @@
 "use client";
 
-import { useState, ReactNode, useEffect, useCallback } from "react";
+import { useState, ReactNode } from "react";
 import { AppHeader } from "@/components/AppHeader";
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { SidebarToggle } from "@/components/ui/sidebar-toggle";
-import { useRouter } from "next/navigation";
 
 interface ClientPageLayoutProps {
-  uuid: string;
   children: ReactNode;
 }
 
-export function ClientPageLayout({ uuid, children }: ClientPageLayoutProps) {
+export function ClientPageLayout({ children }: ClientPageLayoutProps) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-  const [currentThreadId, setCurrentThreadId] = useState<string>(uuid);
-  const router = useRouter();
 
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
-
-  useEffect(() => {
-    if (uuid !== currentThreadId) {
-      setCurrentThreadId(uuid);
-    }
-  }, [uuid, currentThreadId]);
-
-  const handleNewThreadId = useCallback((newThreadId: string) => {
-    if (newThreadId && newThreadId !== currentThreadId) {
-      setCurrentThreadId(newThreadId);
-      router.replace(`/${newThreadId}`);
-    }
-  }, [currentThreadId, router]);
 
   return (
     <div className="flex flex-col h-screen bg-background text-foreground">
@@ -59,10 +42,8 @@ export function ClientPageLayout({ uuid, children }: ClientPageLayoutProps) {
       </div>
 
       <ChatSidebar
-        uuid={currentThreadId}
         isOpen={isSidebarOpen}
         toggleSidebar={toggleSidebar}
-        onNewThreadIdGenerated={handleNewThreadId}
       />
     </div>
   );

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useAgentRun } from "@/hooks/use-agent-run";
+import { useAgentRunCtx } from "@/app/providers/agent-run-provider";
 import { useRouter } from "next/navigation";
 
 // Define the common props and specific props for input and textarea
@@ -59,18 +59,18 @@ function Input({
   const [localLoading, setLocalLoading] = React.useState(false);
 
   const {
+    threadId,
     messages: agentMessages,
     isLoading: agentIsLoading,
     send: sendToAgent,
     error: agentError,
-  } = useAgentRun({
-    threadId: null,
-    initialInput: undefined,
-    onThreadId: (newThreadId: string) => {
-      // Redirect to page with threadId in URL
-      router.push(`/${newThreadId}`);
-    },
-  });
+  } = useAgentRunCtx();
+
+  React.useEffect(() => {
+    if (threadId) {
+      router.push(`/${threadId}`);
+    }
+  }, [threadId, router]);
 
   React.useEffect(() => {
     if (agentMessages.length > 0) {

--- a/frontend/hooks/use-agent-run.ts
+++ b/frontend/hooks/use-agent-run.ts
@@ -29,7 +29,7 @@ export interface UseAgentRunProps {
 }
 
 // Renamed original hook: This hook directly manages the LangGraph stream.
-function useLangGraphStreamAndSend({
+export function useLangGraphStreamAndSend({
   threadId,
   initialInput,
   onThreadId,
@@ -107,7 +107,7 @@ interface AgentQueryData {
 }
 
 // Helper function to process stream error into a consistent Error | null type
-const processStreamError = (error: unknown): Error | null => {
+export const processStreamError = (error: unknown): Error | null => {
   if (!error) return null;
   if (error instanceof Error) return error;
   // Attempt to create an Error from common error-like object structures


### PR DESCRIPTION
## Summary
- implement `AgentRunProvider` to keep a single stream instance
- wrap app providers with `AgentRunProvider`
- update `ChatSidebar` and search `Input` to use the new context
- simplify `ClientPageLayout` props and update dynamic page
- export helper functions from `use-agent-run` hook
- document new files in `AGENTS.md`

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run lint` in `langgraph` *(fails: No files matching the pattern "src")*