### PR TITLE
Fix header home link navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@
 │   │   └── providers/
 │   │       └── agent-run-provider.tsx
 │   ├── components/
+│   │   ├── AppHeader.tsx
+│   │   ├── ChatSidebar.tsx
+│   │   ├── ClientPageLayout.tsx
+│   │   ├── HomeLink.tsx
+│   │   └── ui/
 │   ├── components.json
 │   ├── eslint.config.mjs
 │   ├── lib/

--- a/frontend/components/AppHeader.tsx
+++ b/frontend/components/AppHeader.tsx
@@ -1,6 +1,6 @@
 import { GithubButton } from "@/components/ui/github-button";
 import { ModeToggle } from "@/components/mode-toggle";
-import Link from "next/link";
+import { HomeLink } from "./HomeLink";
 import React from "react";
 
 interface AppHeaderProps {
@@ -10,12 +10,9 @@ interface AppHeaderProps {
 export const AppHeader: React.FC<AppHeaderProps> = ({ sidebarToggle }) => {
   return (
     <header className="flex items-center justify-between p-4 w-full h-full bg-background relative z-10">
-      <Link
-        href="/"
-        className="text-lg font-bold hover:text-primary transition-colors tracking-tight font-geist"
-      >
+      <HomeLink className="text-lg font-bold hover:text-primary transition-colors tracking-tight font-geist">
         Open Websets
-      </Link>
+      </HomeLink>
       <div className="flex items-center">
         <GithubButton />
         <ModeToggle />

--- a/frontend/components/HomeLink.tsx
+++ b/frontend/components/HomeLink.tsx
@@ -1,0 +1,21 @@
+"use client";
+import Link from "next/link";
+import { useAgentRunCtx } from "@/app/providers/agent-run-provider";
+import React from "react";
+
+interface HomeLinkProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const HomeLink: React.FC<HomeLinkProps> = ({ className, children }) => {
+  const { setThreadId } = useAgentRunCtx();
+  const handleClick = () => {
+    setThreadId(null);
+  };
+  return (
+    <Link href="/" className={className} onClick={handleClick}>
+      {children}
+    </Link>
+  );
+};


### PR DESCRIPTION
## Summary
- clear thread state when going home
- create client-side HomeLink component for the header
- update header to use HomeLink
- document new component in AGENTS file

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`