### PR TITLE
Update qualification agent instructions

### DIFF
--- a/langgraph/entity_qualification_agent_js/system_prompt.md
+++ b/langgraph/entity_qualification_agent_js/system_prompt.md
@@ -21,9 +21,10 @@ Your primary objective is to efficiently analyze and qualify (or disqualify) a l
 
 ### Using the `qualify_entities` Tool & Concluding Your Work:
 
-1.  **Comprehensive Update**: When you have processed the entities (i.e., gathered sufficient information, reached search limits, or decided on disqualification for each), use the `qualify_entities` tool.
+1.  **Comprehensive Update**: When you have finished researching every entity (or reached its search limit) and have a final qualification decision for each, call the `qualify_entities` tool. Do **NOT** call this tool if any entity still has unresolved research or placeholder reasoning.
     - **IMPORTANT**: This tool call MUST provide the complete, updated list of qualification summaries for ALL entities you have evaluated or re-evaluated in the current operational step. This tool REPLACES the entire `qualificationSummary` in the state.
     - Each summary item must include `index` (the integer identifier from `entitiesToQualify`), `entity_name`, `qualified` (boolean), and `reasoning` (string).
+    - Ensure every entity has finalized research with complete reasoning; avoid placeholder text like "not yet researched".
     - Example tool call (ensure it reflects all processed entities):
       {
       "name": "qualify_entities",

--- a/langgraph/entity_qualification_agent_js/tools.ts
+++ b/langgraph/entity_qualification_agent_js/tools.ts
@@ -164,8 +164,7 @@ const qualifyAllEntitiesSchema = z.object({
  */
 export const qualifyAllEntitiesTool = new DynamicStructuredTool({
   name: "qualify_entities",
-  description:
-    "Updates or sets the qualification summary for all entities. Provide the complete list of qualification information. This REPLACES the existing summary.",
+  description: "Updates or sets the qualification summary for all entities once research is complete. Call only when every entity has a final qualification decision and no reasoning fields are left as placeholders. This REPLACES the existing summary.",
   schema: qualifyAllEntitiesSchema,
   func: async (args: z.infer<typeof qualifyAllEntitiesSchema>) => {
     // Return an object that instructs the graph to update its state


### PR DESCRIPTION
## Summary
- clarify when the qualification agent should call `qualify_entities`
- update tool description to only allow calling after research is finished

## Testing
- `yarn lint` *(fails: No files matching the pattern "src")*
- `yarn test` *(fails: Cannot find module jest.js)*
- `yarn build` *(fails: TS6133: 'ToolMessage' is declared but its value is never read)*
- `npm run build` in `frontend/`