### PR TITLE
Clarify final qualification step

### DIFF
--- a/langgraph/entity_qualification_agent_js/system_prompt.md
+++ b/langgraph/entity_qualification_agent_js/system_prompt.md
@@ -21,7 +21,7 @@ Your primary objective is to efficiently analyze and qualify (or disqualify) a l
 
 ### Using the `qualify_entities` Tool & Concluding Your Work:
 
-1.  **Comprehensive Update**: When you have finished researching every entity (or reached its search limit) and have a final qualification decision for each, call the `qualify_entities` tool. Do **NOT** call this tool if any entity still has unresolved research or placeholder reasoning.
+1.  **Final Comprehensive Update**: Use the `qualify_entities` tool **only after all searches are complete** and you have a definitive qualification verdict for every entity. This tool is strictly for the final qualification pass. Do **NOT** call it if any entity still has unresolved research or placeholder reasoning.
     - **IMPORTANT**: This tool call MUST provide the complete, updated list of qualification summaries for ALL entities you have evaluated or re-evaluated in the current operational step. This tool REPLACES the entire `qualificationSummary` in the state.
     - Each summary item must include `index` (the integer identifier from `entitiesToQualify`), `entity_name`, `qualified` (boolean), and `reasoning` (string).
     - Ensure every entity has finalized research with complete reasoning; avoid placeholder text like "not yet researched".

--- a/langgraph/entity_qualification_agent_js/tools.ts
+++ b/langgraph/entity_qualification_agent_js/tools.ts
@@ -165,7 +165,7 @@ const qualifyAllEntitiesSchema = z.object({
 export const qualifyAllEntitiesTool = new DynamicStructuredTool({
   name: "qualify_entities",
   description:
-    "Updates or sets the qualification summary for all entities once research is complete. Call only when every entity has a final qualification decision and no reasoning fields are left as placeholders. This REPLACES the existing summary.",
+    "Finalizes the qualification summary for all entities after all research is done. Call this tool only once you have the full verdict for every entity, with no placeholder reasoning remaining. This REPLACES the existing summary in state.",
   schema: qualifyAllEntitiesSchema,
   func: async (args: z.infer<typeof qualifyAllEntitiesSchema>) => {
     // Return an object that instructs the graph to update its state


### PR DESCRIPTION
## Summary
- update system prompt for `entity_qualification_agent_js` to emphasize only calling the `qualify_entities` tool after all research is done
- rewrite tool description to note it is used for the final qualification pass

## Testing
- `npm run lint` *(fails: No files matching the pattern "src" were found)*
- `npm test` *(fails to find jest module)*
- `npm run build` in `frontend/`