### PR TITLE
Implement Gemini stream retry wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@
 │   │   ├── tools.ts
 │   │   ├── tsconfig.json
 │   │   ├── utils.ts
+│   │   ├── chatModelWithRetry.ts
 │   │   └── yarn.lock
 │   ├── entity_qualification_agent_js/
 │   │   ├── configuration.ts
@@ -62,6 +63,7 @@
 │   │   ├── tools.ts
 │   │   ├── tsconfig.json
 │   │   ├── utils.ts
+│   │   ├── chatModelWithRetry.ts
 │   │   └── yarn.lock
 │   ├── auth.mts
 │   ├── configuration.ts
@@ -74,6 +76,7 @@
 │   ├── tools.ts
 │   ├── tsconfig.json
 │   ├── utils.ts
+│   ├── chatModelWithRetry.ts
 │   └── yarn.lock
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ Preview the LangGraph agents with:
 cd langgraph
 npx @langchain/langgraph-cli@latest dev
 ```
+
+### Streaming retry
+All Gemini streaming calls now retry up to 2× on "Failed to parse stream".
+Back-off: 0.5 s → 1 s (±50 % jitter). Disable by importing the raw
+`loadChatModel` instead of `loadChatModelWithRetry`.

--- a/langgraph/chatModelWithRetry.test.ts
+++ b/langgraph/chatModelWithRetry.test.ts
@@ -1,0 +1,26 @@
+import { jest } from "@jest/globals";
+import { GoogleGenerativeAIError } from "@google/generative-ai";
+
+const mockLoadChatModel = jest.fn();
+
+jest.unstable_mockModule("./utils.js", () => ({
+  loadChatModel: mockLoadChatModel,
+}));
+
+const { loadChatModelWithRetry } = await import("./chatModelWithRetry.js");
+
+const mockModel: any = { generateContentStream: jest.fn() };
+// @ts-ignore
+(mockModel.generateContentStream as any)
+  .mockRejectedValueOnce(new GoogleGenerativeAIError("Failed to parse stream"))
+  .mockResolvedValue("ok");
+
+// @ts-ignore
+(mockLoadChatModel as any).mockResolvedValue(mockModel);
+
+test("retries parsing failures", async () => {
+  const model: any = await loadChatModelWithRetry("gemini");
+  const result = await model.generateContentStream([]);
+  expect(result).toBe("ok");
+  expect(mockModel.generateContentStream).toHaveBeenCalledTimes(2);
+});

--- a/langgraph/chatModelWithRetry.ts
+++ b/langgraph/chatModelWithRetry.ts
@@ -1,0 +1,55 @@
+import { loadChatModel } from "./utils.js";
+import { GoogleGenerativeAIError } from "@google/generative-ai";
+
+const MAX_ATTEMPTS = 3;
+
+function isParseError(err: unknown): err is GoogleGenerativeAIError {
+  return (
+    err instanceof GoogleGenerativeAIError &&
+    err.message.includes("Failed to parse stream")
+  );
+}
+
+function backoffMs(attempt: number) {
+  const base = 500 * Math.pow(2, attempt - 1);
+  const jitter = base * (Math.random() - 0.5);
+  return base + jitter;
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function loadChatModelWithRetry(modelName: string) {
+  const realModel: any = await loadChatModel(modelName);
+
+  async function generateContentStreamWithRetry(...args: any[]): Promise<any> {
+    const options = args[1] as { signal?: AbortSignal } | undefined;
+    if (options?.signal?.aborted) {
+      return realModel.generateContentStream(...args);
+    }
+    try {
+      return await realModel.generateContentStream(...args);
+    } catch (err) {
+      const attempt = (options as any)?.__retryAttempt || 1;
+      const shouldRetry = isParseError(err) && attempt < MAX_ATTEMPTS;
+      if (!shouldRetry) throw err;
+      console.warn("[Gemini-retry] attempt", attempt + 1, "…");
+      await wait(backoffMs(attempt));
+      return generateContentStreamWithRetry(
+        args[0],
+        Object.assign({}, options, { __retryAttempt: attempt + 1 }) as any,
+      );
+    }
+  }
+
+  return new Proxy(realModel, {
+    get(target, prop, receiver) {
+      if (prop === "generateContentStream") {
+        return generateContentStreamWithRetry;
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}

--- a/langgraph/entity_qualification_agent_js/chatModelWithRetry.ts
+++ b/langgraph/entity_qualification_agent_js/chatModelWithRetry.ts
@@ -1,0 +1,55 @@
+import { loadChatModel } from "./utils.js";
+import { GoogleGenerativeAIError } from "@google/generative-ai";
+
+const MAX_ATTEMPTS = 3;
+
+function isParseError(err: unknown): err is GoogleGenerativeAIError {
+  return (
+    err instanceof GoogleGenerativeAIError &&
+    err.message.includes("Failed to parse stream")
+  );
+}
+
+function backoffMs(attempt: number) {
+  const base = 500 * Math.pow(2, attempt - 1);
+  const jitter = base * (Math.random() - 0.5);
+  return base + jitter;
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function loadChatModelWithRetry(modelName: string) {
+  const realModel: any = await loadChatModel(modelName);
+
+  async function generateContentStreamWithRetry(...args: any[]): Promise<any> {
+    const options = args[1] as { signal?: AbortSignal } | undefined;
+    if (options?.signal?.aborted) {
+      return realModel.generateContentStream(...args);
+    }
+    try {
+      return await realModel.generateContentStream(...args);
+    } catch (err) {
+      const attempt = (options as any)?.__retryAttempt || 1;
+      const shouldRetry = isParseError(err) && attempt < MAX_ATTEMPTS;
+      if (!shouldRetry) throw err;
+      console.warn("[Gemini-retry] attempt", attempt + 1, "…");
+      await wait(backoffMs(attempt));
+      return generateContentStreamWithRetry(
+        args[0],
+        Object.assign({}, options, { __retryAttempt: attempt + 1 }) as any,
+      );
+    }
+  }
+
+  return new Proxy(realModel, {
+    get(target, prop, receiver) {
+      if (prop === "generateContentStream") {
+        return generateContentStreamWithRetry;
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}

--- a/langgraph/entity_qualification_agent_js/graph.ts
+++ b/langgraph/entity_qualification_agent_js/graph.ts
@@ -16,7 +16,7 @@ import {
   verifyQualificationConsistencyTool,
 } from "./tools.js";
 import { type Entity } from "../list_gen_agent_js/graph.js";
-import { loadChatModel } from "./utils.js";
+import { loadChatModelWithRetry as loadChatModel } from "./chatModelWithRetry.js";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";

--- a/langgraph/graph.ts
+++ b/langgraph/graph.ts
@@ -12,7 +12,7 @@ import {
 import { ToolNode } from "@langchain/langgraph/prebuilt";
 import { ConfigurationSchema, ensureConfiguration } from "./configuration.js";
 import { TOOLS } from "./tools.js";
-import { loadChatModel } from "./utils.js";
+import { loadChatModelWithRetry as loadChatModel } from "./chatModelWithRetry.js";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";

--- a/langgraph/list_gen_agent_js/chatModelWithRetry.ts
+++ b/langgraph/list_gen_agent_js/chatModelWithRetry.ts
@@ -1,0 +1,55 @@
+import { loadChatModel } from "./utils.js";
+import { GoogleGenerativeAIError } from "@google/generative-ai";
+
+const MAX_ATTEMPTS = 3;
+
+function isParseError(err: unknown): err is GoogleGenerativeAIError {
+  return (
+    err instanceof GoogleGenerativeAIError &&
+    err.message.includes("Failed to parse stream")
+  );
+}
+
+function backoffMs(attempt: number) {
+  const base = 500 * Math.pow(2, attempt - 1);
+  const jitter = base * (Math.random() - 0.5);
+  return base + jitter;
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function loadChatModelWithRetry(modelName: string) {
+  const realModel: any = await loadChatModel(modelName);
+
+  async function generateContentStreamWithRetry(...args: any[]): Promise<any> {
+    const options = args[1] as { signal?: AbortSignal } | undefined;
+    if (options?.signal?.aborted) {
+      return realModel.generateContentStream(...args);
+    }
+    try {
+      return await realModel.generateContentStream(...args);
+    } catch (err) {
+      const attempt = (options as any)?.__retryAttempt || 1;
+      const shouldRetry = isParseError(err) && attempt < MAX_ATTEMPTS;
+      if (!shouldRetry) throw err;
+      console.warn("[Gemini-retry] attempt", attempt + 1, "…");
+      await wait(backoffMs(attempt));
+      return generateContentStreamWithRetry(
+        args[0],
+        Object.assign({}, options, { __retryAttempt: attempt + 1 }) as any,
+      );
+    }
+  }
+
+  return new Proxy(realModel, {
+    get(target, prop, receiver) {
+      if (prop === "generateContentStream") {
+        return generateContentStreamWithRetry;
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}

--- a/langgraph/list_gen_agent_js/graph.ts
+++ b/langgraph/list_gen_agent_js/graph.ts
@@ -5,7 +5,7 @@ import { ToolNode } from "@langchain/langgraph/prebuilt";
 
 import { ConfigurationSchema, ensureConfiguration } from "./configuration.js";
 import { TOOLS, addEntityIndexes } from "./tools.js";
-import { loadChatModel } from "./utils.js";
+import { loadChatModelWithRetry as loadChatModel } from "./chatModelWithRetry.js";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";


### PR DESCRIPTION
## Summary
- create `chatModelWithRetry.ts` proxy for Gemini models
- retry Gemini streaming failures with exponential backoff
- update root and subgraph graphs to use the wrapper
- add unit test for wrapper behaviour
- document streaming retries in README
- update project file structure in AGENTS.md

## Testing
- `npm run build` in `frontend/`
- `yarn lint` *(fails: No files matching the pattern "src" were found)*
- `yarn test`