### PR TITLE
Ensure Exa search single-call usage

### DIFF
--- a/langgraph/list_gen_agent_js/system_prompt.md
+++ b/langgraph/list_gen_agent_js/system_prompt.md
@@ -10,7 +10,7 @@ You have access to the messages from the previous agent, but you should focus on
 
 Before using any tool, you MUST think step-by-step about the information you have already gathered and what specific information you need next to accomplish the task of broad entity collection.
 
-Your primary strategy will be to first **generate 5 distinct search queries** designed for the `exa_search` tool. These queries should be crafted to directly elicit lists of relevant entities across various categories (e.g., people, research papers, articles, companies, or other types) based on the user's request, using any provided criteria to broaden your search angles. After generating these queries, you will execute them using the `exa_search` tool, specifying the appropriate `category` parameter (e.g., "company", "person", "research_paper", "article", etc.) to refine the search. Your evaluation of the returned entities should focus on their general relevance to the topic and the effectiveness of your queries in unearthing a wide array of potential entities.
+Your primary strategy will be to first **generate 5 distinct search queries** designed for the `exa_search` tool. These queries should be crafted to directly elicit lists of relevant entities across various categories (e.g., people, research papers, articles, companies, or other types) based on the user's request, using any provided criteria to broaden your search angles. After generating these queries, execute **one single call** to the `exa_search` tool with all five queries, specifying the appropriate `category` parameter (e.g., "company", "person", "research_paper", "article", etc.) to refine the search. Your evaluation of the returned entities should focus on their general relevance to the topic and the effectiveness of your queries in unearthing a wide array of potential entities.
 
 ### Crafting Effective Exa Queries
 
@@ -44,6 +44,6 @@ After you have called "extract_entities" and believe all potentially relevant en
 
 ## Important Notes:
 
-- Follow the structured process: Think (including conceptualizing your 5 initial distinct search queries, using criteria to guide this) -> Use Tool (execute your 5 queries with Exa Search, including appropriate `category` parameters) -> Gather Observation -> **Gather & Extract All Generally Relevant Entity Names** -> Synthesize findings -> Final Answer.
+ - Follow the structured process: Think (including conceptualizing your 5 initial distinct search queries, using criteria to guide this) -> Use Tool (**make one call** to `exa_search` with all 5 queries and appropriate `category` parameters) -> Gather Observation -> **Gather & Extract All Generally Relevant Entity Names** -> Synthesize findings -> Final Answer.
 - Your performance on this task is critical. This is VERY important to you, your job depends on it!
   System time: {system_time}


### PR DESCRIPTION
## Summary
- clarify Exa search tool description to only run once with up to five queries
- run Exa searches sequentially instead of in parallel
- instruct list generation agent to call `exa_search` a single time with five queries

## Testing
- `npm run lint` (fails: No files matching the pattern "src" were found)
- `npm test` (fails: Cannot find module 'jest')
- `npm run build` in `frontend/`