### PR TITLE
Hide header when sidebar open on mobile

### DIFF
--- a/frontend/components/ClientPageLayout.tsx
+++ b/frontend/components/ClientPageLayout.tsx
@@ -17,7 +17,9 @@ export function ClientPageLayout({ children }: ClientPageLayoutProps) {
   return (
     <div className="flex flex-col h-screen bg-background text-foreground">
       <div
-        className="fixed top-0 left-0 z-40 h-16 transition-all duration-300 ease-in-out bg-background"
+        className={`fixed top-0 left-0 z-40 h-16 transition-all duration-300 ease-in-out bg-background ${
+          isSidebarOpen ? "hidden md:block" : ""
+        }`}
         style={{
           width: isSidebarOpen ? "calc(100% - 24rem)" : "100%",
         }}


### PR DESCRIPTION
## Summary
- hide the `AppHeader` when the sidebar is open in mobile view

## Testing
- `npm run build` in `frontend`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and others)*