### PR TITLE
Improve mobile viewport behavior

### DIFF
--- a/frontend/app/client-providers.tsx
+++ b/frontend/app/client-providers.tsx
@@ -1,16 +1,25 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { AgentRunProvider } from "./providers/agent-run-provider";
-import React from "react";
+import React, { useEffect } from "react";
 
 // Single QueryClient instance for all client-side React Query usage
 const queryClient = new QueryClient();
 
 export function ClientProviders({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const setVH = () => {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty("--vh", `${vh}px`);
+    };
+    setVH();
+    window.addEventListener("resize", setVH);
+    return () => window.removeEventListener("resize", setVH);
+  }, []);
   return (
     <QueryClientProvider client={queryClient}>
       <AgentRunProvider>
@@ -28,4 +37,4 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
       </AgentRunProvider>
     </QueryClientProvider>
   );
-} 
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,12 +5,14 @@ import { AppHeader } from "@/components/AppHeader";
 import { OptionsDrawer } from "@/components/OptionsDrawer";
 
 export default function Home() {
-
   return (
-    <div className="flex flex-col h-screen bg-background text-foreground" style={{
-      height: '100dvh', // Use dynamic viewport height for better mobile support
-      minHeight: '100vh', // Fallback for browsers that don't support dvh
-    }}>
+    <div
+      className="flex flex-col h-screen bg-background text-foreground"
+      style={{
+        height: "calc(var(--vh, 1vh) * 100)",
+        minHeight: "100vh",
+      }}
+    >
       <div className="w-full flex-shrink-0">
         <AppHeader />
       </div>
@@ -51,7 +53,7 @@ export default function Home() {
           </div>
         </div>
       </div>
-      
+
       <div className="flex-shrink-0">
         <OptionsDrawer />
       </div>

--- a/frontend/components/ClientPageLayout.tsx
+++ b/frontend/components/ClientPageLayout.tsx
@@ -15,10 +15,13 @@ export function ClientPageLayout({ children }: ClientPageLayoutProps) {
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 
   return (
-    <div className="flex flex-col h-screen bg-background text-foreground" style={{
-      height: '100dvh',
-      minHeight: '100vh',
-    }}>
+    <div
+      className="flex flex-col h-screen bg-background text-foreground"
+      style={{
+        height: "calc(var(--vh, 1vh) * 100)",
+        minHeight: "100vh",
+      }}
+    >
       <div
         className={`fixed top-0 left-0 z-40 h-16 transition-all duration-300 ease-in-out bg-background ${
           isSidebarOpen ? "hidden md:block" : ""
@@ -46,10 +49,7 @@ export function ClientPageLayout({ children }: ClientPageLayoutProps) {
         </main>
       </div>
 
-      <ChatSidebar
-        isOpen={isSidebarOpen}
-        toggleSidebar={toggleSidebar}
-      />
+      <ChatSidebar isOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use JS to set `--vh` CSS variable based on `window.innerHeight`
- apply `--vh` to `ClientPageLayout` and the home page

## Testing
- `npm run build` in `frontend/`
- `npm run lint` *(fails: Unexpected any, etc.)*