### PR TITLE
Fix mobile viewport height

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,14 +7,17 @@ import { OptionsDrawer } from "@/components/OptionsDrawer";
 export default function Home() {
 
   return (
-    <div className="flex flex-col h-screen bg-background text-foreground" style={{
-      height: '100dvh', // Use dynamic viewport height for better mobile support
-      minHeight: '100vh', // Fallback for browsers that don't support dvh
-    }}>
+    <div
+      className="flex flex-col h-screen bg-background text-foreground overflow-hidden"
+      style={{
+        height: '100dvh', // Dynamic viewport height for better mobile support
+        minHeight: '100vh', // Fallback for browsers that don't support dvh
+      }}
+    >
       <div className="w-full flex-shrink-0">
         <AppHeader />
       </div>
-      <div className="flex items-center justify-center flex-1 w-full px-4 -mt-40 overflow-hidden">
+      <div className="flex items-center justify-center flex-1 w-full px-4 overflow-hidden lg:-mt-40">
         <div className="text-center max-w-lg w-full">
           <h1 className="text-2xl font-bold tracking-tight">
             Find your (almost) perfect list

--- a/frontend/components/ClientPageLayout.tsx
+++ b/frontend/components/ClientPageLayout.tsx
@@ -15,10 +15,13 @@ export function ClientPageLayout({ children }: ClientPageLayoutProps) {
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 
   return (
-    <div className="flex flex-col h-screen bg-background text-foreground" style={{
-      height: '100dvh',
-      minHeight: '100vh',
-    }}>
+    <div
+      className="flex flex-col h-screen bg-background text-foreground overflow-hidden"
+      style={{
+        height: '100dvh', // Dynamic viewport height for mobile browsers
+        minHeight: '100vh',
+      }}
+    >
       <div
         className={`fixed top-0 left-0 z-40 h-16 transition-all duration-300 ease-in-out bg-background ${
           isSidebarOpen ? "hidden md:block" : ""


### PR DESCRIPTION
## Summary
- adjust `Home` layout so the full screen fits the dynamic viewport
- ensure `ClientPageLayout` also uses dynamic viewport height

## Testing
- `npm run lint` *(fails: Unexpected any and other eslint errors)*
- `npm run build`