### PR TITLE
Remove debug logging from frontend

### DIFF
--- a/frontend/components/AgentGrid.tsx
+++ b/frontend/components/AgentGrid.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useMemo, useEffect, useState, useCallback } from "react";
+import React, { useMemo, useEffect, useState } from "react";
 import { useAgentRunCtx } from "@/app/providers/agent-run-provider";
 import { LoadExternalComponent } from "@langchain/langgraph-sdk/react-ui";
 import { useTheme } from "next-themes";
@@ -12,7 +12,7 @@ export interface AgentGridProps {
 function AgentGridComponent({}: AgentGridProps) {
   // Consume the stream and UI from the AgentRunProvider context so that
   // this component stays in sync with the rest of the app.
-  const { ui, isLoading, error, stream } = useAgentRunCtx();
+  const { ui, isLoading, stream } = useAgentRunCtx();
   const { resolvedTheme } = useTheme();
 
   // Wait until the component is mounted on the client to avoid SSR/CSR
@@ -32,11 +32,9 @@ function AgentGridComponent({}: AgentGridProps) {
     return gridMessages.length > 0 ? gridMessages[gridMessages.length - 1] : null;
   }, [gridMessages]);
 
-  // Only log when there are actual changes, not on every render
+  // Track changes if needed in the future
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
-      console.log(`[AgentGrid] UI updated: ${ui?.length || 0} items, grid messages: ${gridMessages.length}, loading: ${isLoading}`);
-    }
+    // Intentionally left blank - side effects can be added here if required
   }, [ui?.length, gridMessages.length, isLoading]);
 
   const themeMetadata = useMemo(() => ({

--- a/frontend/components/ui/audio-visualizer.tsx
+++ b/frontend/components/ui/audio-visualizer.tsx
@@ -101,8 +101,8 @@ export function AudioVisualizer({
       source.connect(analyser);
 
       draw();
-    } catch (error) {
-      console.error("Error starting visualization:", error);
+    } catch {
+      // Error starting visualization
     }
   };
 

--- a/frontend/components/ui/chat-message.tsx
+++ b/frontend/components/ui/chat-message.tsx
@@ -172,10 +172,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
     // Important: Do not log warning if parts or toolInvocations are present,
     // as 'content' might be irrelevant or structured differently in those cases.
     if (!parts?.length && !toolInvocations?.length) {
-      console.warn(
-        `ChatMessage's 'content' prop received an unexpected value for direct rendering and no parts/tools. Got:`,
-        content
-      );
+      // Unexpected value for rendering
     }
     renderableTopLevelContent = ""; // Default to empty if content is not a recognized format for text
   }

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -60,10 +60,8 @@ function Input({
 
   const {
     threadId,
-    messages: agentMessages,
     isLoading: agentIsLoading,
     send: sendToAgent,
-    error: agentError,
   } = useAgentRunCtx();
 
   React.useEffect(() => {
@@ -72,17 +70,6 @@ function Input({
     }
   }, [threadId, router]);
 
-  React.useEffect(() => {
-    if (agentMessages.length > 0) {
-      console.log("Agent messages:", agentMessages);
-    }
-  }, [agentMessages]);
-
-  React.useEffect(() => {
-    if (agentError) {
-      console.error("Agent run error:", agentError);
-    }
-  }, [agentError]);
 
   const isControlled = propValue !== undefined;
   const displayValue = isControlled ? propValue : internalValue;

--- a/frontend/hooks/use-agent-run.ts
+++ b/frontend/hooks/use-agent-run.ts
@@ -55,18 +55,12 @@ export function useLangGraphStreamAndSend({
     reconnectDelay: 1000,
     onThreadId,
     onCustomEvent: (event, options) => {
-      if (process.env.NODE_ENV === 'development') {
-        console.log("[useStream] Custom event received:", (event as any)?.type, (event as any)?.name || 'unnamed');
-      }
       // Handle UI message events using the mutate function following the LangGraph documentation
       options.mutate(prev => {
         // Use the built-in uiMessageReducer to handle UI state updates properly
         const currentUI = prev?.ui ?? [];
         const updatedUI = uiMessageReducer(currentUI, event as any);
-        if (process.env.NODE_ENV === 'development' && currentUI.length !== updatedUI.length) {
-          console.log("[useStream] UI updated from", currentUI.length, "to", updatedUI.length, "items");
-        }
-
+        
         return {
           ...prev,
           ui: updatedUI,
@@ -147,11 +141,9 @@ export function useAgentRun(props: UseAgentRunProps) {
   // For now, just directly return the stream hook to test if React Query was the issue
   const streamHook = useLangGraphStreamAndSend(props);
   
-  // Add debug logging only in development and only when UI actually changes
+  // Track UI changes if needed in the future
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
-      console.log("[useAgentRun] UI state updated:", streamHook.ui?.length || 0, "items");
-    }
+    // Intentionally left blank - side effects can be added here if required
   }, [streamHook.ui?.length]);
   
   return {

--- a/frontend/hooks/use-audio-recording.ts
+++ b/frontend/hooks/use-audio-recording.ts
@@ -43,7 +43,7 @@ export function useAudioRecording({
         onTranscriptionComplete?.(text);
       }
     } catch (error) {
-      console.error("Error transcribing audio:", error);
+      // Error transcribing audio
     } finally {
       setIsTranscribing(false);
       setIsListening(false);
@@ -69,7 +69,7 @@ export function useAudioRecording({
         // Begin recording
         activeRecordingRef.current = recordAudio(stream);
       } catch (error) {
-        console.error("Error recording audio:", error);
+        // Error recording audio
         setIsListening(false);
         setIsRecording(false);
         if (audioStream) {


### PR DESCRIPTION
## Summary
- drop console logs and warnings from the frontend
- remove unused imports and variables
- replace unused catch params after removing logs

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars in unrelated files)*
- `npm run build`