### PR TITLE
Add reconnectOnMount option

### DIFF
--- a/frontend/hooks/use-agent-run.ts
+++ b/frontend/hooks/use-agent-run.ts
@@ -92,6 +92,7 @@ export function useLangGraphStreamAndSend({
     recursionLimit: 50,
     reconnect: true,
     reconnectDelay: 1000,
+    reconnectOnMount: true,
     onThreadId,
   } as UseStreamOptions<AgentState, { UpdateType: AgentUpdate }>);
 


### PR DESCRIPTION
## Summary
- reconnect automatically when mounting a thread

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683e34d29274832290677c7af509d9d0