### PR TITLE
Enable auto row height for grid reasoning column

### DIFF
--- a/frontend/components/AgentGrid.tsx
+++ b/frontend/components/AgentGrid.tsx
@@ -123,11 +123,12 @@ function AgentGridComponent({}: AgentGridProps) {
         return 0; // A and B are of equal priority for sorting
       },
     },
-    { 
-      field: "reasoning", 
-      headerName: "Reasoning", 
-      flex: 3, 
+    {
+      field: "reasoning",
+      headerName: "Reasoning",
+      flex: 3,
       wrapText: true,
+      autoHeight: true,
       cellRenderer: (params: { data: RowItem }) => {
         // Show "pending research" in italics if entity hasn't been qualified yet
         if (params.data.qualified === null) {


### PR DESCRIPTION
## Summary
- enable autoHeight with wrapText for the Reasoning column

## Testing
- `npm run lint` *(fails: npm not found)*
- `npm run build` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f54e1af50832287ea8d9155fe574a