### PR TITLE
Enable auto row height for grid reasoning column

### DIFF
--- a/frontend/components/AgentGrid.tsx
+++ b/frontend/components/AgentGrid.tsx
@@ -80,7 +80,7 @@ function AgentGridComponent({}: AgentGridProps) {
   // Define column definitions
   const columnDefs: ColDef<RowItem>[] = useMemo(() => [
     { field: "index", headerName: "Index", sortable: true, hide: true },
-    { field: "name", headerName: "Name", sortable: true, flex: 1 },
+    { field: "name", headerName: "Name", sortable: true, flex: 1, wrapText: true },
     {
       field: "url",
       headerName: "URL",
@@ -123,11 +123,12 @@ function AgentGridComponent({}: AgentGridProps) {
         return 0; // A and B are of equal priority for sorting
       },
     },
-    { 
-      field: "reasoning", 
-      headerName: "Reasoning", 
-      flex: 3, 
+    {
+      field: "reasoning",
+      headerName: "Reasoning",
+      flex: 3,
       wrapText: true,
+      autoHeight: true,
       cellRenderer: (params: { data: RowItem }) => {
         // Show "pending research" in italics if entity hasn't been qualified yet
         if (params.data.qualified === null) {


### PR DESCRIPTION
## Summary
- enable autoHeight with wrapText for the Reasoning column
- allow wrapping text in the Name column

## Testing
- `npm run lint` *(fails: ESLint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f54e1af50832287ea8d9155fe574a