### PR TITLE
feat: Collapse chat sidebar by default on mobile

### DIFF
--- a/frontend/components/ClientPageLayout.tsx
+++ b/frontend/components/ClientPageLayout.tsx
@@ -1,3 +1,4 @@
+import { useIsMobile } from "@/hooks/use-mobile";
 "use client";
 
 import { useState, ReactNode } from "react";
@@ -10,7 +11,8 @@ interface ClientPageLayoutProps {
 }
 
 export function ClientPageLayout({ children }: ClientPageLayoutProps) {
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const isMobile = useIsMobile();
+  const [isSidebarOpen, setIsSidebarOpen] = useState(!isMobile);
 
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 


### PR DESCRIPTION
The chat sidebar in ClientPageLayout.tsx now uses the useIsMobile hook to determine its initial state.

- If you are on a mobile device (screen width < 768px), the sidebar will be collapsed by default.
- If you are on a desktop device, the sidebar will be open by default.

The toggle functionality remains unchanged.