### PR TITLE
Collapse chat sidebar on mobile

### DIFF
--- a/frontend/components/ClientPageLayout.tsx
+++ b/frontend/components/ClientPageLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, ReactNode } from "react";
+import { useState, ReactNode, useEffect } from "react";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { AppHeader } from "@/components/AppHeader";
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { SidebarToggle } from "@/components/ui/sidebar-toggle";
@@ -10,7 +11,14 @@ interface ClientPageLayoutProps {
 }
 
 export function ClientPageLayout({ children }: ClientPageLayoutProps) {
+  const isMobile = useIsMobile();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
+  useEffect(() => {
+    if (isMobile) {
+      setIsSidebarOpen(false);
+    }
+  }, [isMobile]);
 
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 


### PR DESCRIPTION
## Summary
- close the chat sidebar by default on mobile screens

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841d671dc8483229c38d6cb9e09146a