### PR TITLE
Fix: Prevent word break in agent grid name column

### DIFF
--- a/frontend/components/AgentGrid.tsx
+++ b/frontend/components/AgentGrid.tsx
@@ -88,7 +88,7 @@ function AgentGridComponent({}: AgentGridProps) {
       flex: 1,
       wrapText: true,
       autoHeight: true,
-      cellStyle: { lineHeight: "1.5", padding: "4px 12px" } as CellStyle,
+      cellStyle: { lineHeight: "1.5", padding: "4px 12px", "word-break": "break-word" } as CellStyle,
     },
     {
       field: "url",


### PR DESCRIPTION
Updated the cellStyle for the 'name' column in AgentGrid.tsx to include 'word-break: break-word'. This ensures that text in the name column wraps at word boundaries rather than breaking individual words, aligning its behavior with the 'reasoning' column.