### PR TITLE
Fix AgentGrid word wrap

### DIFF
--- a/frontend/components/AgentGrid.tsx
+++ b/frontend/components/AgentGrid.tsx
@@ -88,7 +88,11 @@ function AgentGridComponent({}: AgentGridProps) {
       flex: 1,
       wrapText: true,
       autoHeight: true,
-      cellStyle: { lineHeight: "1.5", padding: "4px 12px" } as CellStyle,
+      cellStyle: {
+        lineHeight: "1.5",
+        padding: "4px 12px",
+        wordBreak: "normal",
+      } as CellStyle,
     },
     {
       field: "url",


### PR DESCRIPTION
## Summary
- keep agent names from splitting mid-word by customizing the AG Grid column

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run build`
- `npm test` in `langgraph`

------
https://chatgpt.com/codex/tasks/task_e_684325806c888322835989a4053681c2