### PR TITLE
Allow name column width to break on hyphen

### DIFF
--- a/frontend/components/AgentGrid.tsx
+++ b/frontend/components/AgentGrid.tsx
@@ -80,11 +80,13 @@ function AgentGridComponent({}: AgentGridProps) {
   }, [entities, qualificationSummary]);
 
   // Determine the length of the longest word in the "name" column so we can
-  // size the column to fit it without breaking the word.
+  // size the column to fit it without breaking the word. Treat hyphen ("-") as
+  // a possible line break to avoid overly wide columns for hyphenated names.
   const longestNameWordLength = useMemo(() => {
     let maxWord = 0;
     for (const { name } of entities) {
-      const words = name.split(/\s+/);
+      // Split on whitespace or hyphen so hyphenated words can wrap
+      const words = name.split(/[\s-]+/);
       for (const w of words) {
         if (w.length > maxWord) {
           maxWord = w.length;


### PR DESCRIPTION
## Summary
- let AG Grid name column word-length calculation split words on `-`

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68518f187dec8322a3e69c9fbff78e39